### PR TITLE
ibm_is_security_group_rule should be inbound

### DIFF
--- a/examples/ibm-cluster/roks-on-vpc-gen2/roks_on_vpc/roks_on_vpc.tf
+++ b/examples/ibm-cluster/roks-on-vpc-gen2/roks_on_vpc/roks_on_vpc.tf
@@ -17,7 +17,7 @@ resource "ibm_is_vpc" "vpc1" {
 
 resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
     group = ibm_is_vpc.vpc1.default_security_group
-    direction = "outbound"
+    direction = "inbound"
     tcp {
         port_min = 30000
         port_max = 32767


### PR DESCRIPTION
Ref: https://cloud.ibm.com/docs/openshift?topic=openshift-getting-started#vpc-gen2-gs. Step 2b:  "In the Inbound rules section, click New rule."